### PR TITLE
Create stale PR action

### DIFF
--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -1,0 +1,31 @@
+name: Close stale PR containing merge conflicts
+# This action will close automatically every PR already marked with "merge conflict" label
+#   without activity for more than X days.
+# This action is not adding a new label. It's an extension of the merge conflict action.
+# The label will be added by "merge conflict" action.
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write, read
+
+    steps:
+      - uses: actions/stale@v6.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: -1
+          # using 1 day for testing
+          days-before-close: 1
+          any-of-labels: 'merge conflict'
+          exempt-pr-labels: 'Internal, Documentation Needed'
+          exempt-draft-pr: true
+          exempt-all-pr-assignees: true
+          operations-per-run: 300
+          close-pr-message: 'This PR was considered abandoned (it has merge conflicts and it was not updated on the last 30 days).'


### PR DESCRIPTION
### What does this PR aim to accomplish?:

Automatically close every PR marked with `merge conflict` label and without updates on the last N days.

Suggestion:
- run the action only if the PR is marked with `merge conflict`;
- don't run the action on a draft PR;
- close PR after 30 days of "inactivity".

### How does this PR accomplish the above?:

This action **does not** mark a PR as "stale".
The PR will be marked by the merge conflict action (or manually).
It only closes every PR marked with `merge conflict` label **and** not updated on the last N days.

### Note:
Using test values. 
The texts should be changed before production.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
